### PR TITLE
[-] MO : Add module name in the view in PaymentExample

### DIFF
--- a/paymentexample.php
+++ b/paymentexample.php
@@ -177,6 +177,6 @@ class PaymentExample extends PaymentModule
             'years' => $years,
         ]);
 
-        return $this->context->smarty->fetch('module:views/templates/front/payment_form.tpl');
+        return $this->context->smarty->fetch('module:paymentexample/views/templates/front/payment_form.tpl');
     }
 }


### PR DESCRIPTION
In the smarty template the url is missing the module name.

It make crash the payment page
