### PR TITLE
Do not set use statement

### DIFF
--- a/paymentexample.php
+++ b/paymentexample.php
@@ -24,8 +24,6 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -109,7 +107,7 @@ class PaymentExample extends PaymentModule
 
     public function getOfflinePaymentOption()
     {
-        $offlineOption = new PaymentOption();
+        $offlineOption = new \PrestaShop\PrestaShop\Core\Payment\PaymentOption();
         $offlineOption->setCallToActionText($this->l('Pay offline'))
                       ->setAction($this->context->link->getModuleLink($this->name, 'validation', array(), true))
                       ->setAdditionalInformation($this->context->smarty->fetch('module:paymentexample/views/templates/front/payment_infos.tpl'))
@@ -120,7 +118,7 @@ class PaymentExample extends PaymentModule
 
     public function getExternalPaymentOption()
     {
-        $externalOption = new PaymentOption();
+        $externalOption = new \PrestaShop\PrestaShop\Core\Payment\PaymentOption();
         $externalOption->setCallToActionText($this->l('Pay external'))
                        ->setAction($this->context->link->getModuleLink($this->name, 'validation', array(), true))
                        ->setInputs([
@@ -138,7 +136,7 @@ class PaymentExample extends PaymentModule
 
     public function getEmbeddedPaymentOption()
     {
-        $embeddedOption = new PaymentOption();
+        $embeddedOption = new \PrestaShop\PrestaShop\Core\Payment\PaymentOption();
         $embeddedOption->setCallToActionText($this->l('Pay embedded'))
                        ->setForm($this->generateForm())
                        ->setAdditionalInformation($this->context->smarty->fetch('module:paymentexample/views/templates/front/payment_infos.tpl'))
@@ -149,7 +147,7 @@ class PaymentExample extends PaymentModule
 
     public function getIframePaymentOption()
     {
-        $iframeOption = new PaymentOption();
+        $iframeOption = new \PrestaShop\PrestaShop\Core\Payment\PaymentOption();
         $iframeOption->setCallToActionText($this->l('Pay iframe'))
                      ->setAction($this->context->link->getModuleLink($this->name, 'iframe', array(), true))
                      ->setAdditionalInformation($this->context->smarty->fetch('module:paymentexample/views/templates/front/payment_infos.tpl'))


### PR DESCRIPTION
Although the original version is working, this PR removes `use PrestaShop\PrestaShop\Core\Payment\PaymentOption;`. By doing so, we allow module developers to reuse this content and build modules compatible with PrestaShop 1.7, 1.6 and below.

If we have a payment module on PrestaShop with `use PrestaShop\PrestaShop\Core\Payment\PaymentOption`, the autoloader will directly try to load this non-existing class and will end in a fatal error.
If we move the namespace in each `new` statement, we delay the autoloading at the moment the hook is executed (which never happens on PS 1.6). Then you can then mix the hooks for previous versions of PrestaShop and you get a module compatible with all the version you want.